### PR TITLE
Optimize dependency by moving gazebo-dependent stuff to gazebo pkg.

### DIFF
--- a/spur_description/urdf/spur.urdf.xacro
+++ b/spur_description/urdf/spur.urdf.xacro
@@ -9,7 +9,6 @@
 
   <!-- include materials -->
   <xacro:include filename="$(find spur_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find spur_description)/urdf/spur.gazebo.xacro" />
 
   <!-- constants -->
   <property name="M_PI" value="3.1415926535897931" />

--- a/spur_gazebo/launch/spur_world.launch
+++ b/spur_gazebo/launch/spur_world.launch
@@ -5,7 +5,7 @@
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
 
-  <arg name="model" value="$(find spur_description)/urdf/spur.urdf.xacro"  />
+  <arg name="model" value="$(find spur_gazebo)/urdf/spur.gazebo.xacro"  />
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="debug" value="$(arg debug)" />

--- a/spur_gazebo/urdf/spur.gazebo.xacro
+++ b/spur_gazebo/urdf/spur.gazebo.xacro
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="spur"
+       xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:include filename="$(find spur_description)/urdf/spur.urdf.xacro" />
+
   <!-- ros_control plugin -->
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">


### PR DESCRIPTION
so that nothing in `spur_description` depends on Gazebo-related stuff.

It seems indeed a common practice in ROS to put Gazebo xacro files into `*-description` packages (see my small research below). I've made this commit primarily as my learning process, so if this doesn't look good for any reason please close.

```
$ locate gazebo.urdf.xacro
/home/notriussmall/catkin_ws/src/pr2_common/pr2_description/gazebo/gazebo.urdf.xacro
/home/notriussmall/cws_industrial/src/ros-industrial/universal_robot/ur_description/urdf/gazebo.urdf.xacro
/home/notriussmall/cws_reem/src/reem_robot/reem_description/gazebo/gazebo.urdf.xacro
/home/notriussmall/turtlebot/.hg/store/data/turtlebot__description/urdf/gazebo.urdf.xacro.i
/home/notriussmall/turtlebot/turtlebot_description/urdf/gazebo.urdf.xacro
/opt/ros/hydro/share/pr2_description/gazebo/gazebo.urdf.xacro
```
