### PR TITLE
Add launch for teleop to remap Twist topic name.

### DIFF
--- a/spur_controller/launch/kb_teleop.launch
+++ b/spur_controller/launch/kb_teleop.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop_kb" output="screen">
+    <remap from="/cmd_vel" to="spur/cmd_vel"/>
+  </node>
+</launch>


### PR DESCRIPTION
Spur uses a topic name `/spur/cmd_vel`. 
Since `teleop_twist_keyboard.py` seems not to accept arguments for custom topic name, this PR was needed (although I'm not sure if this is the best way).