### PR TITLE
Adjust model and base_controller to the real robot config

### DIFF
--- a/spur_controller/nodes/base_controller.py
+++ b/spur_controller/nodes/base_controller.py
@@ -162,10 +162,10 @@ class BaseController:
         self.pub_fl_w.publish(Float64(   fl_v/(diameter / 2.0)))
         self.pub_br_w.publish(Float64(-1*br_v/(diameter / 2.0)))
         self.pub_bl_w.publish(Float64(   bl_v/(diameter / 2.0)))
-        self.pub_fr_r.publish(Float64(fr_a))
-        self.pub_fl_r.publish(Float64(fl_a))
-        self.pub_br_r.publish(Float64(br_a))
-        self.pub_bl_r.publish(Float64(bl_a))
+        self.pub_fr_r.publish(Float64(-1*fr_a))  # All steerage wheels' rotational direction needs
+        self.pub_fl_r.publish(Float64(-1*fl_a))  # to be negated since they are upside down.
+        self.pub_br_r.publish(Float64(-1*br_a))
+        self.pub_bl_r.publish(Float64(-1*bl_a))
         self.pub_odom.publish(self.odom)
 
     def cmdCb(self, msg):

--- a/spur_description/urdf/spur.urdf.xacro
+++ b/spur_description/urdf/spur.urdf.xacro
@@ -95,7 +95,7 @@
 
   <xacro:macro name="odom_wheel_rotate" params="suffix">
     <joint name="${suffix}_rotation_joint" type="revolute">
-      <axis xyz="0 0 1" />
+      <axis xyz="0 0 -1" />
       <limit lower="${-90*M_PI/180.0}" upper="${90*M_PI/180.0}" effort="300" velocity="1"/>
       <dynamics damping="50.0" friction="1.0" />
       <xacro:insert_block name="origin" />


### PR DESCRIPTION
With this the robot base moves as intended `Twist` value.

Only caveat remaining is linear Y direction seems opposite:

```
$ rostopic pub -r 1 /spur/cmd_vel geometry_msgs/Twist "linear: {x: 0, y: -0.01}"   <-- Moves to the right
$ rostopic pub -r 1 /spur/cmd_vel geometry_gs/Twist "linear: {x: 0, y: 0.01}"         <-- Moves to the left
```
