### PR TITLE
Allow configuring idle time for Twist command.

### DIFF
--- a/spur/package.xml
+++ b/spur/package.xml
@@ -2,10 +2,12 @@
 <package>
   <name>spur</name>
   <version>0.1.3</version>
-  <description>The spur package</description>
+  <description>Meta package for SPUR omni-directional mobile manipulator robot made at Tamagawa University.</description>
 
+  <maintainer email="okdhryk@gmail.com">Hiroyuki Okada</maintainer>
   <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
   <author email="534o@opensource-robotics.tokyo.jp">Tokyo Opensource Robotics Programmer 534o</author>
+  <author>Isaac I. Y. Saito</author>
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/spur</url>
   <url type="bugtracker">https://github.com/tork-a/spur/issues</url>

--- a/spur_controller/config/spur_controller_configuration_gen.sh
+++ b/spur_controller/config/spur_controller_configuration_gen.sh
@@ -2,8 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association.
-# All rights reserved.
+# Copyright (c) 2015, Tamagawa University All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/spur_controller/launch/base_controller.launch
+++ b/spur_controller/launch/base_controller.launch
@@ -1,6 +1,9 @@
 <launch>
+  <arg name="sec_idle" default="3.0" />
+  
   <node pkg="spur_controller" name="spur_base_controller"
         type="base_controller.py" output="screen" ns="/spur">
+    <param name="sec_idle" value="$(arg sec_idle)" />
     <remap from="spur/cmd_vel" to="/spur/cmd_vel" />
     <remap from="odom" to="/odom" />
   </node>

--- a/spur_controller/launch/spur_controller.launch
+++ b/spur_controller/launch/spur_controller.launch
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="sec_idle" default="1.0" />
+
   <!-- Debug Info -->
   <arg name="sim" default="false" />
   <arg unless="$(arg sim)" name="spur_controller_args" default="" />
@@ -23,7 +25,9 @@
   </include>
 
   <!-- Start the Base Controller -->
-  <include file="$(find spur_controller)/launch/base_controller.launch" />
+  <include file="$(find spur_controller)/launch/base_controller.launch">
+    <arg name="sec_idle" value="$(arg sec_idle)"/>
+  </include>
 
   <!-- convert joint states to TF transforms for rviz, etc -->
   <node name="robot_state_publisher" pkg="robot_state_publisher"

--- a/spur_controller/nodes/base_controller.py
+++ b/spur_controller/nodes/base_controller.py
@@ -38,24 +38,30 @@ velocity to the base_controller and then plots the actual outputs.
 """
 
 import argparse
-import rospy
-import sys, time
+import time
 import numpy
-from math import sin, cos, asin, acos, atan2, hypot, fabs, pi
+from math import atan2, hypot, fabs, pi
+
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry
-from sensor_msgs.msg import JointState
+import rospy
 from std_msgs.msg import Float64
 from tf.transformations import quaternion_multiply, quaternion_about_axis, quaternion_matrix, translation_matrix
 
-# visualization
-from pylab import *
 
 class BaseController:
+    '''
+    Units:
+      - x is m/s, accel_x is m/s^2
+      - r is rad/s, accel_r is rad/s^2
 
-    ## x is m/s, accel_x is m/s^2
-    ## r is rad/s, accel_r is rad/s^2
+    '''
     def __init__(self):
+        '''
+        @brief Instantiate each joint's publisher that publishes Float64 as
+               position/velocity (velocity for wheels that rotate about pitch,
+               position for yaw).
+        '''
         self.sub = rospy.Subscriber("spur/cmd_vel", Twist, self.cmdCb)
         self.pub_bl_r = rospy.Publisher("bl_rotation_joint_position_controller/command", Float64, queue_size=1)
         self.pub_br_r = rospy.Publisher("br_rotation_joint_position_controller/command", Float64, queue_size=1)
@@ -90,6 +96,12 @@ class BaseController:
         time.sleep(1)
 
     def control(self):
+        '''
+        @brief Intended to be called periodically.
+               Reads the last velocity command, interpretes for SPUR mechanism,
+               then publish as Float64 that is the data type
+               dynamixel_controllers receive.
+        '''
         control_interval = (rospy.Time.now() - self.last_control_time).to_sec()
         self.last_control_time = rospy.Time.now()
 
@@ -114,23 +126,23 @@ class BaseController:
             self.last_cmd_msg = Twist()
 
         velocity_limit = 0.001
-        self.cmd.linear.x += max(min(self.last_cmd_msg.linear.x - self.cmd.linear.x ,velocity_limit),-velocity_limit)
-        self.cmd.linear.y += max(min(self.last_cmd_msg.linear.y - self.cmd.linear.y ,velocity_limit),-velocity_limit)
-        self.cmd.angular.z += max(min(self.last_cmd_msg.angular.z - self.cmd.angular.z ,velocity_limit),-velocity_limit)
+        self.cmd.linear.x += max(min(self.last_cmd_msg.linear.x - self.cmd.linear.x, velocity_limit), -velocity_limit)
+        self.cmd.linear.y += max(min(self.last_cmd_msg.linear.y - self.cmd.linear.y, velocity_limit), -velocity_limit)
+        self.cmd.angular.z += max(min(self.last_cmd_msg.angular.z - self.cmd.angular.z, velocity_limit), -velocity_limit)
         rospy.logdebug("cmd_vel %f %f %f" % (self.cmd.linear.x, self.cmd.linear.y, self.cmd.angular.z))
 
         diameter = 0.1  # caster diameter
-        offset_x = 0.15 # caster offset
+        offset_x = 0.15  # caster offset
         offset_y = 0.15
         #
         # http://www.chiefdelphi.com/media/papers/download/2614
         fr_v_x = self.cmd.linear.x - self.cmd.angular.z * (-offset_y)
-        fr_v_y = self.cmd.linear.y + self.cmd.angular.z * ( offset_x)
-        fl_v_x = self.cmd.linear.x - self.cmd.angular.z * ( offset_y)
-        fl_v_y = self.cmd.linear.y + self.cmd.angular.z * ( offset_x)
+        fr_v_y = self.cmd.linear.y + self.cmd.angular.z * (offset_x)
+        fl_v_x = self.cmd.linear.x - self.cmd.angular.z * (offset_y)
+        fl_v_y = self.cmd.linear.y + self.cmd.angular.z * (offset_x)
         br_v_x = self.cmd.linear.x - self.cmd.angular.z * (-offset_y)
         br_v_y = self.cmd.linear.y + self.cmd.angular.z * (-offset_x)
-        bl_v_x = self.cmd.linear.x - self.cmd.angular.z * ( offset_y)
+        bl_v_x = self.cmd.linear.x - self.cmd.angular.z * (offset_y)
         bl_v_y = self.cmd.linear.y + self.cmd.angular.z * (-offset_x)
         # v[m/s] = r[rad/s] * 0.1[m]  ## 0.1 = diameter
         fr_v = hypot(fr_v_x, fr_v_y)
@@ -143,22 +155,23 @@ class BaseController:
         bl_a = atan2(bl_v_y, bl_v_x)
 
         # fix for -pi/2 - pi/2
-        fr_v = -fr_v if fabs(fr_a) > pi/2 else fr_v
-        fr_a =  fr_a - pi if fr_a >  pi/2 else fr_a
-        fr_a =  fr_a + pi if fr_a < -pi/2 else fr_a
-        fl_v = -fl_v if fabs(fl_a) > pi/2 else fl_v
-        fl_a =  fl_a - pi if fl_a >  pi/2 else fl_a
-        fl_a =  fl_a + pi if fl_a < -pi/2 else fl_a
-        br_v = -br_v if fabs(br_a) > pi/2 else br_v
-        br_a =  br_a - pi if br_a >  pi/2 else br_a
-        br_a =  br_a + pi if br_a < -pi/2 else br_a
-        bl_v = -bl_v if fabs(bl_a) > pi/2 else bl_v
-        bl_a =  bl_a - pi if bl_a >  pi/2 else bl_a
-        bl_a =  bl_a + pi if bl_a < -pi/2 else bl_a
-            
+        fr_v = -fr_v if fabs(fr_a) > pi / 2 else fr_v
+        fr_a = fr_a - pi if fr_a > pi / 2 else fr_a
+        fr_a = fr_a + pi if fr_a < -pi / 2 else fr_a
+        fl_v = -fl_v if fabs(fl_a) > pi / 2 else fl_v
+        fl_a = fl_a - pi if fl_a > pi / 2 else fl_a
+        fl_a = fl_a + pi if fl_a < -pi / 2 else fl_a
+        br_v = -br_v if fabs(br_a) > pi / 2 else br_v
+        br_a = br_a - pi if br_a > pi / 2 else br_a
+        br_a = br_a + pi if br_a < -pi / 2 else br_a
+        bl_v = -bl_v if fabs(bl_a) > pi / 2 else bl_v
+        bl_a = bl_a - pi if bl_a > pi / 2 else bl_a
+        bl_a = bl_a + pi if bl_a < -pi / 2 else bl_a
+
         rospy.logdebug("wheel   %f %f %f %f" % (fr_v, fl_v, br_v, bl_v))
         rospy.logdebug("rotate  %f %f %f %f" % (fr_a, fl_a, br_a, bl_a))
-        self.pub_fr_w.publish(Float64(-1*fr_v/(diameter / 2.0))) # right wheel has -1 axis orientation
+
+        self.pub_fr_w.publish(Float64(-1*fr_v/(diameter / 2.0)))  # right wheel has -1 axis orientation
         self.pub_fl_w.publish(Float64(   fl_v/(diameter / 2.0)))
         self.pub_br_w.publish(Float64(-1*br_v/(diameter / 2.0)))
         self.pub_bl_w.publish(Float64(   bl_v/(diameter / 2.0)))
@@ -173,8 +186,10 @@ class BaseController:
         self.last_cmd_time = rospy.Time.now()
         rospy.logdebug("cmd_vel %f %f %f" % (msg.linear.x, msg.linear.y, msg.angular.z))
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description = __doc__)
+    # Accept control rate. Default is 100 hz.
     parser.add_argument("--rate", help="Controller rate", type=float, default=100.0)
     args, unknown = parser.parse_known_args()
 
@@ -182,13 +197,12 @@ if __name__ == "__main__":
         rospy.init_node("spur_base_controller")
 
         b = BaseController()
-        rate = rospy.Rate(args.rate) 
+        rate = rospy.Rate(args.rate)
 
+        # Keep looping unless the system receives shutdown signal.
         while not rospy.is_shutdown():
             b.control()
             rate.sleep()
 
     except rospy.ROSInterruptException:
         pass
-
-

--- a/spur_controller/nodes/base_controller.py
+++ b/spur_controller/nodes/base_controller.py
@@ -2,8 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association.
-# All rights reserved.
+# Copyright (c) 2015, Tamagawa University. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/spur_controller/package.xml
+++ b/spur_controller/package.xml
@@ -2,13 +2,13 @@
 <package>
   <name>spur_controller</name>
   <version>0.1.3</version>
-  <description>The spur_controller package</description>
+  <description>A package for mobile base control for SPUR omni-directional mobile manipulator robot made at Tamagawa University.</description>
 
+  <maintainer email="okdhryk@gmail.com">Hiroyuki Okada</maintainer>
   <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
-
   <license>BSD</license>
-
   <author email="534o@opensource-robotics.tokyo.jp">Tokyo Opensource Robotics Programmer 534o</author>
+  <author>Isaac I. Y. Saito</author>
 
   <url type="website">http://wiki.ros.org/spur_controller</url>
   <url type="bugtracker">https://github.com/tork-a/spur/issues</url>

--- a/spur_description/package.xml
+++ b/spur_description/package.xml
@@ -2,13 +2,13 @@
 <package>
   <name>spur_description</name>
   <version>0.1.3</version>
-  <description>The spur_description package</description>
+  <description>A package for storing 3D model of SPUR omni-directional mobile manipulator robot made at Tamagawa University.</description>
 
+  <maintainer email="okdhryk@gmail.com">Hiroyuki Okada</maintainer>
   <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
-
   <license>BSD</license>
-
   <author email="534o@opensource-robotics.tokyo.jp">Tokyo Opensource Robotics Programmer 534o</author>
+  <author>Isaac I. Y. Saito</author>
 
   <url type="website">http://wiki.ros.org/spur_description</url>
   <url type="bugtracker">https://github.com/tork-a/spur/issues</url>
@@ -18,7 +18,6 @@
 
   <build_depend>urdf</build_depend>
   <build_depend>xacro</build_depend>
-
   <run_depend>rviz</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>urdf_tutorial</run_depend>

--- a/spur_gazebo/config/spur_gazebo_control_gen.sh
+++ b/spur_gazebo/config/spur_gazebo_control_gen.sh
@@ -2,8 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association.
-# All rights reserved.
+# Copyright (c) 2015, Tamagawa University All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/spur_gazebo/launch/spur_world.launch
+++ b/spur_gazebo/launch/spur_world.launch
@@ -4,6 +4,7 @@
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
+  <arg name="sec_idle" default="1.0" />
 
   <arg name="model" value="$(find spur_description)/urdf/spur.urdf.xacro"  />
 
@@ -21,5 +22,7 @@
         args="-z 1.0 -unpause -urdf -model spur -param robot_description" />
 
   <include file="$(find spur_gazebo)/launch/spur_gazebo_control.launch" />
-  <include file="$(find spur_controller)/launch/base_controller.launch" />
+  <include file="$(find spur_controller)/launch/base_controller.launch">
+    <arg name="sec_idle" value="$(arg sec_idle)"/>
+  </include>
 </launch>

--- a/spur_gazebo/package.xml
+++ b/spur_gazebo/package.xml
@@ -2,13 +2,13 @@
 <package>
   <name>spur_gazebo</name>
   <version>0.1.3</version>
-  <description>The spur_description package</description>
+  <description>3D simulation package for SPUR omni-directional mobile manipulator robot made at Tamagawa University.</description>
 
+  <maintainer email="okdhryk@gmail.com">Hiroyuki Okada</maintainer>
   <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
-
   <license>BSD</license>
-
   <author email="534o@opensource-robotics.tokyo.jp">Tokyo Opensource Robotics Programmer 534o</author>
+  <author>Isaac I. Y. Saito</author>
 
   <url type="website">http://wiki.ros.org/spur_gazebo</url>
   <url type="bugtracker">https://github.com/tork-a/spur/issues</url>


### PR DESCRIPTION
Per request from an end user of the robot. With this the users can launch controllers as follows.

With Gazebo:
```
$ roslaunch spur_gazebo spur_world.launch 
$ roslaunch spur_gazebo spur_world.launch sec_idle:=1.5
```
With real robot:
```
$ roslaunch spur_controller spur_controller.launch
$ roslaunch spur_controller spur_controller.launch sec_idle:=1.5
```

