### PR TITLE
Correct CMake build rule (Fix #40)

### DIFF
--- a/spur_2dnav/CMakeLists.txt
+++ b/spur_2dnav/CMakeLists.txt
@@ -4,14 +4,7 @@ project(spur_2dnav)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  amcl
-  dwa_local_planner
-  gmapping
-  map_server
-  move_base
-  tf
-)
+find_package(catkin REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/spur_bringup/CMakeLists.txt
+++ b/spur_bringup/CMakeLists.txt
@@ -4,10 +4,7 @@ project(spur_bringup)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  urg_node
-  rostest
-)
+find_package(catkin REQUIRED rostest)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)


### PR DESCRIPTION
Don't know why locally neither `catkin build` nor `catkin_make` failed though.