### PR TITLE
fix rviz laser configuration

### DIFF
--- a/spur_bringup/launch/minimal.launch
+++ b/spur_bringup/launch/minimal.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="sec_idle" default="1.0" />
+  <arg name="use_base_odom" default="true" />
 
   <!-- Debug Info -->
   <arg name="sim" default="false" />
@@ -13,6 +14,7 @@
   <include file="$(find spur_controller)/launch/spur_controller.launch">
     <arg name="sec_idle" value="$(arg sec_idle)" />
     <arg name="sim" value="$(arg sim)" />
+    <arg name="use_base_odom" value="$(arg use_base_odom)" />
     <arg name="spur_controller_args" default="$(arg spur_controller_args)" />
     <arg name="debug" value="false" />
   </include>

--- a/spur_controller/launch/base_controller.launch
+++ b/spur_controller/launch/base_controller.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="sec_idle" default="3.0" />
-  <arg name="use_base_odom" default="false" />
+  <arg name="use_base_odom" default="true" />
   
   <node pkg="spur_controller" name="spur_base_controller"
         type="base_controller.py" output="screen" ns="/spur">

--- a/spur_controller/launch/spur_controller.launch
+++ b/spur_controller/launch/spur_controller.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="sec_idle" default="1.0" />
+  <arg name="use_base_odom" default="true" />
 
   <!-- Debug Info -->
   <arg name="sim" default="false" />
@@ -28,6 +29,7 @@
   <!-- Start the Base Controller -->
   <include file="$(find spur_controller)/launch/base_controller.launch">
     <arg name="sec_idle" value="$(arg sec_idle)"/>
+    <arg name="use_base_odom" value="$(arg use_base_odom)" />
   </include>
 
   <!-- convert joint states to TF transforms for rviz, etc -->

--- a/spur_description/urdf/spur.urdf.xacro
+++ b/spur_description/urdf/spur.urdf.xacro
@@ -351,7 +351,7 @@
       <inertia ixx="0.3"  ixy="0.3"  ixz="0.3" iyy="0.3"  iyz="0.3"  izz="0.3" /> 
     </inertial> 
     <visual> 
-      <origin xyz="0 0 0" rpy="3.14 0 0"/> 
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry> 
       <!-- <cylinder length="${hokuyo_length}" radius="${hokuyo_radius}" /> -->
         <mesh filename="package://gazebo_plugins/test/multi_robot_scenario/meshes/laser/hokuyo.dae"/> 
@@ -365,7 +365,7 @@
      </collision> 
   </link> 
   <joint name="laser_to_base" type="fixed"> 
-    <origin xyz="${caster_offset_x} 0 -0.05" rpy="0 0 0" /> 
+    <origin xyz="${caster_offset_x} 0 -0.05" rpy="3.14 0 0" />
     <parent link="base_link" /> 
     <child link="hokuyo_sensor_link"/> 
   </joint> 


### PR DESCRIPTION
set use_base_odom to true as default, if you want to use laser_odom, run 
```
roslaunch spur_bringup minimal.launch  use_base_odom:=false
```